### PR TITLE
Limit on times and button disables

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,12 +36,12 @@
         <div class="time-input">
           <div class="minutes-input">
             <p>Minutes</p>
-            <input onkeyup="value=value.replace(/[^\d]/g,'')" min= "1" max="90" type="number" id="minutes">
+            <input onkeyup="value=value.replace(/[^\d]/g,'')" min= "1" max="90" type="number" id="minutes" placeholder="Max value is 90 minutes">
             <span class="minutes-input-error hidden"><img class="minutes-icon" src="./assets/warning.svg">  Minutes are required.</span>
           </div>
           <div class="seconds-input">
             <p>Seconds</p>
-            <input onkeyup="value=value.replace(/[^\d]/g,'')" min="1" max="59" type="number" id="seconds">
+            <input onkeyup="value=value.replace(/[^\d]/g,'')" min="1" max="59" type="number" id="seconds" placeholder="Max value is 59 seconds">
             <span class="seconds-input-error hidden"><img class="seconds-icon" src="./assets/warning.svg"> Seconds are required.</span>
           </div>
         </div>

--- a/main.js
+++ b/main.js
@@ -28,6 +28,7 @@ activityButton.addEventListener('click', dataValidate);
 buttonWrap.addEventListener("click", buttonState);
 buttonWrap.addEventListener("click", setCategory);
 startButton.addEventListener("click", timerCountdown);
+activityButton.addEventListener("mouseover", timeLimits);
 
 
   function buttonState(event) {
@@ -114,6 +115,16 @@ function dataValidate() {
   }
 }
 
+function timeLimits() {
+  if (minutesInput.value >= 90) {
+    secondsInput.value = 0
+    minutesInput.value = 90;
+  }
+  if (secondsInput.value >= 59) {
+    secondsInput.value = 59;
+  }
+}
+
 function displayTime() {
   if (minutesInput.value < 10) {minutesInput.value = `0${minutesInput.value}`};
   if (secondsInput.value < 10) {secondsInput.value = `0${secondsInput.value}`};
@@ -121,6 +132,7 @@ function displayTime() {
 }
 
 function timerCountdown() {
+  startButton.disabled = true;
   timeDisplay.classList.add("hidden");
   var totalSeconds = Number((minutesInput.value) * 60) + Number(secondsInput.value);
   var interval = setInterval(countdown, 1000)


### PR DESCRIPTION
## Is this a fix or a feature?
fix

## What is the change?
the minutes and seconds inputs now have limits and have placeholders
the start button is disabled after being clicked 

## What does it fix?
the minutes and seconds inputs now have limits.

## Where should the reviewer start?
index.html line 44

## How should this be tested?
-from the main screen the user should enter minutes greater then 90 and seconds greater then 59
-check the minutes defaults to 90 and the seconds defaults to 0
- On the current activity page the try 'clicking' the start button more then once

##Screenshots(if appropriate)


